### PR TITLE
Hotfix: Microsoft Exchange Online Auth for TLS

### DIFF
--- a/Kernel/System/MailAccount/IMAPOAuth2.pm
+++ b/Kernel/System/MailAccount/IMAPOAuth2.pm
@@ -72,7 +72,7 @@ sub Connect {
     my $Socket = IO::Socket::SSL->new(  
        PeerAddr => $Param{Host},  
        PeerPort => 993,
-       SSL_verify_mode => SSL_VERIFY_NONE
+       SSL_verify_mode => 0,
     );
 
     if ( !$Socket ) {

--- a/Kernel/System/MailAccount/IMAPOAuth2.pm
+++ b/Kernel/System/MailAccount/IMAPOAuth2.pm
@@ -22,6 +22,7 @@ use warnings;
 
 use Mail::IMAPClient;
 use MIME::Base64;
+use IO::Socket::SSL;
 
 use Kernel::System::PostMaster;
 
@@ -68,11 +69,25 @@ sub Connect {
     }
 
     # connect to host
+    my $Socket = IO::Socket::SSL->new(  
+       PeerAddr => $Param{Host},  
+       PeerPort => 993,
+       SSL_verify_mode => SSL_VERIFY_NONE
+    );
+
+    if ( !$Socket ) {
+        return (
+            Successful => 0,
+            Message    => "IMAPOAuth2: Can't open a socket for $Param{Host}: $@\n"
+        );
+    }
+
     my $IMAPObject = Mail::IMAPClient->new(
         Server   => $Param{Host},
         Starttls => [ SSL_verify_mode => 0 ],
         Debug    => $Param{Debug},
         Uid      => 1,
+        Socket   => $Socket,
 
         # see bug#8791: needed for some Microsoft Exchange backends
         Ignoresizeerrors => 1,

--- a/Kernel/System/MailAccount/IMAPOAuth2.pm
+++ b/Kernel/System/MailAccount/IMAPOAuth2.pm
@@ -22,7 +22,6 @@ use warnings;
 
 use Mail::IMAPClient;
 use MIME::Base64;
-use IO::Socket::SSL;
 
 use Kernel::System::PostMaster;
 
@@ -69,25 +68,11 @@ sub Connect {
     }
 
     # connect to host
-    my $Socket = IO::Socket::SSL->new(  
-       PeerAddr => $Param{Host},  
-       PeerPort => 993,
-       SSL_verify_mode => 0,
-    );
-
-    if ( !$Socket ) {
-        return (
-            Successful => 0,
-            Message    => "IMAPOAuth2: Can't open a socket for $Param{Host}: $@\n"
-        );
-    }
-
     my $IMAPObject = Mail::IMAPClient->new(
         Server   => $Param{Host},
-        Starttls => [ SSL_verify_mode => 0 ],
+        Ssl      => 1,
         Debug    => $Param{Debug},
         Uid      => 1,
-        Socket   => $Socket,
 
         # see bug#8791: needed for some Microsoft Exchange backends
         Ignoresizeerrors => 1,


### PR DESCRIPTION
Currently, multiple systems are facing problems pulling their mail via IMAPTLS from Microsoft Exchange Online.

This PR creates a socket beforehand and passes the socket to the IMAP client.

This does not seem to be an issue for POP3.