### PR TITLE
Fixed: encode_base64 sometimes destroys OAuth Token

### DIFF
--- a/Kernel/System/MailAccount/IMAPOAuth2.pm
+++ b/Kernel/System/MailAccount/IMAPOAuth2.pm
@@ -79,7 +79,7 @@ sub Connect {
     );
 
     # Auth via SASL XOAUTH2.
-    my $SASLXOAUTH2 = encode_base64( 'user=' . $Param{Login} . "\x01auth=Bearer " . $AccessToken . "\x01\x01" );
+    my $SASLXOAUTH2 = encode_base64( 'user=' . $Param{Login} . "\x01auth=Bearer " . $AccessToken . "\x01\x01", "" );
     $IMAPObject->authenticate( 'XOAUTH2', sub { return $SASLXOAUTH2 } );
 
     if ( !$IMAPObject || !$IMAPObject->IsAuthenticated() ) {

--- a/Kernel/System/MailAccount/POP3OAuth2.pm
+++ b/Kernel/System/MailAccount/POP3OAuth2.pm
@@ -85,7 +85,7 @@ sub Connect {
         );
     }
 
-    my $SASLXOAUTH2 = encode_base64( 'user=' . $Param{Login} . "\x01auth=Bearer " . $AccessToken . "\x01\x01" );
+    my $SASLXOAUTH2 = encode_base64( 'user=' . $Param{Login} . "\x01auth=Bearer " . $AccessToken . "\x01\x01", "" );
     $PopObject->command( 'AUTH', 'XOAUTH2' )->response();
     my $NOM = $PopObject->command($SASLXOAUTH2)->response();
 


### PR DESCRIPTION
Siehe Doku zur Funktion:

https://perldoc.perl.org/MIME::Base64